### PR TITLE
Added "0x" prefix to print_int.

### DIFF
--- a/examples/quine.in
+++ b/examples/quine.in
@@ -37,12 +37,6 @@
 
 :repeat
         #
-        #  Print a prefix for the bytes.
-        #
-        store #5, "0x"
-        print_str #5
-
-        #
         #  Get the contents of the byte and show it
         #
         peek #5, #3

--- a/simple-vm-opcodes.c
+++ b/simple-vm-opcodes.c
@@ -343,7 +343,7 @@ void op_int_print(struct svm *svm)
     if (getenv("DEBUG") != NULL)
         printf("[STDOUT] Register R%02d => %d [Hex:%04x]\n", reg, val, val);
     else
-        printf("%02X", val);
+        printf("Ox%04X", val);
 
 
     /* handle the next instruction */


### PR DESCRIPTION
The new formatting string is "Ox%04X", so numbers
are padded four spaces.

The quine.in example was updated to avoid printing
a double "0x" prefix.