### PR TITLE
docs: fix simple typo, staticly -> statically

### DIFF
--- a/src/embedded.c
+++ b/src/embedded.c
@@ -62,7 +62,7 @@ void op_custom(struct svm *svm)
 
 
 /**
- * Run the staticly-defined bytecode at the head of this script, after
+ * Run the statically-defined bytecode at the head of this script, after
  * defining a custom opcode.
  */
 int run_vm()


### PR DESCRIPTION
There is a small typo in src/embedded.c.

Should read `statically` rather than `staticly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md