### PR TITLE
Move stack increment higher

### DIFF
--- a/src/simple-vm-opcodes.c
+++ b/src/simple-vm-opcodes.c
@@ -1164,6 +1164,8 @@ void op_stack_call(struct svm *svm)
 
 
     int sp_size = sizeof(svm->stack) / sizeof(svm->stack[0]);
+    svm->SP += 1;
+
     if (svm->SP >= sp_size)
         svm_default_error_handler(svm, "stack overflow - stack is full!");
 
@@ -1172,9 +1174,6 @@ void op_stack_call(struct svm *svm)
      * on the stack so that the "ret(urn)" instruction will go
      * to the correct place.
      */
-    svm->SP += 1;
-
-
     svm->stack[svm->SP] = svm->ip + 1;
 
     /**


### PR DESCRIPTION
This can potentially be turned into an information leak.
If SP = 1023, then it will pass the check before being updated to 1024.

This gives us an off-by-1 array overwrite `svm->stack[svm->SP] = svm->ip + 1;`

The value we write to is SP
 ```
     * only a small number of entries permitted.
     */
    int stack[1024];

    /**
     * The stack pointer which starts from zero and grows upwards.
     */
    int SP;
```

We can now set SP to any value in the range 0 - 0xffff

If you check the opcodes for the stack, the values allowing us to write have a upper bound check
 ```
 if (svm->SP >= sp_size)
        svm_default_error_handler(svm, "stack overflow - stack is full!");
```
However the opcodes for reading only have a lower bound check
```
/* ensure we're not outside the stack. */
    if (svm->SP <= 0)
        svm_default_error_handler(svm, "stack overflow - stack is empty");
```

So we can leak memory outside the stack by using pop

In terms of what values we can actually leak, if we make careful malloc and free calls, we can leak us some pointers
to other bins eventually getting to the ELF base or the malloc internals to get to libc base.
