### PR TITLE
Add wrap around

### DIFF
--- a/src/simple-vm-opcodes.c
+++ b/src/simple-vm-opcodes.c
@@ -188,6 +188,9 @@ char *string_from_stack(svm_t * svm)
     memset(tmp, '\0', len + 1);
     for (int i = 0; i < (int) len; i++)
     {
+        if (svm->ip >= 0xFFFF)
+            svm->ip = 0;
+        
         tmp[i] = svm->code[svm->ip];
         svm->ip++;
     }


### PR DESCRIPTION
In the string from stack function, an OOB can happen

if ip = 0xffff & len = 0xffff

```
    /* the string length */
    unsigned int len1 = next_byte(svm);
    unsigned int len2 = next_byte(svm);

    /* build up the length 0-64k */
    int len = BYTES_TO_ADDR(len1, len2);
```
then as we start to copy
```
for (int i = 0; i < (int) len; i++)
    {

        tmp[i] = svm->code[svm->ip];
        svm->ip++;
    }
```
We will continue to read into tmp, without any bounds checking.
Then if we do some heap magic, we can leak some useful data getting ELF or libc base.